### PR TITLE
add multiple input sizes for the go benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,18 @@ for _, _ = range messages {
 
 ### Comparison against channels 
 ```sql
-BenchmarkConsumerSequentialReadWrite-8               849           1261116 ns/op            1060 B/op          4 allocs/op
-BenchmarkChannelsSequentialReadWrite-8               453           2640028 ns/op             896 B/op          1 allocs/op
-BenchmarkConsumerConcurrentReadWrite-8               235           5095339 ns/op         4102668 B/op         37 allocs/op
-BenchmarkChannelsConcurrentReadWrite-8                79          15557314 ns/op         4102493 B/op         33 allocs/op
+BenchmarkConsumerSequentialReadWriteLarge-8            8         127404589 ns/op            1060 B/op          4 allocs/op
+BenchmarkChannelsSequentialReadWriteLarge-8            4         265133938 ns/op             898 B/op          1 allocs/op
+BenchmarkConsumerSequentialReadWriteMedium-8         942           1264458 ns/op            1060 B/op          4 allocs/op
+BenchmarkChannelsSequentialReadWriteMedium-8         452           2655275 ns/op             896 B/op          1 allocs/op
+BenchmarkConsumerSequentialReadWriteSmall-8        94333             12593 ns/op            1060 B/op          4 allocs/op
+BenchmarkChannelsSequentialReadWriteSmall-8        45060             26648 ns/op             896 B/op          1 allocs/op
+BenchmarkConsumerConcurrentReadWriteLarge-8            2         520416396 ns/op        492003812 B/op        65 allocs/op
+BenchmarkChannelsConcurrentReadWriteLarge-8            1        1245517208 ns/op        492002264 B/op        59 allocs/op
+BenchmarkConsumerConcurrentReadWriteMedium-8         235           5097063 ns/op         4102692 B/op         37 allocs/op
+BenchmarkChannelsConcurrentReadWriteMedium-8         100          12909553 ns/op         4102507 B/op         33 allocs/op
+BenchmarkConsumerConcurrentReadWriteSmall-8        30693             39371 ns/op           26424 B/op         21 allocs/op
+BenchmarkChannelsConcurrentReadWriteSmall-8        22174             53359 ns/op           26241 B/op         17 allocs/op
 ```
 
 In sequential benchmarks it is about double the read write speed of channels and in concurrent benchmarks where 

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -5,15 +5,39 @@ import (
 	"testing"
 )
 
-func BenchmarkConsumerSequentialReadWrite(b *testing.B) {
+func BenchmarkConsumerSequentialReadWriteLarge(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		ConsumerSequentialReadWrite(10000000)
+	}
+}
+
+func BenchmarkChannelsSequentialReadWriteLarge(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		ChannelsSequentialReadWrite(10000000)
+	}
+}
+
+func BenchmarkConsumerSequentialReadWriteMedium(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		ConsumerSequentialReadWrite(100000)
 	}
 }
 
-func BenchmarkChannelsSequentialReadWrite(b *testing.B) {
+func BenchmarkChannelsSequentialReadWriteMedium(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		ChannelsSequentialReadWrite(100000)
+	}
+}
+
+func BenchmarkConsumerSequentialReadWriteSmall(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		ConsumerSequentialReadWrite(1000)
+	}
+}
+
+func BenchmarkChannelsSequentialReadWriteSmall(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		ChannelsSequentialReadWrite(1000)
 	}
 }
 
@@ -42,15 +66,38 @@ func ChannelsSequentialReadWrite(n int) {
 General Benchmark to compare concurrent reading from channels vrs the ring buffer.
 Note there is heavy over head for syncing the routines in both and is not accurate beyond a general comparison.
 */
-func BenchmarkConsumerConcurrentReadWrite(b *testing.B) {
+func BenchmarkConsumerConcurrentReadWriteLarge(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		ConsumerConcurrentReadWrite(10000000)
+	}
+}
+
+func BenchmarkChannelsConcurrentReadWriteLarge(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		ChannelsConcurrentReadWrite(10000000)
+	}
+}
+
+func BenchmarkConsumerConcurrentReadWriteMedium(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		ConsumerConcurrentReadWrite(100000)
 	}
 }
 
-func BenchmarkChannelsConcurrentReadWrite(b *testing.B) {
+func BenchmarkChannelsConcurrentReadWriteMedium(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		ChannelsConcurrentReadWrite(100000)
+	}
+}
+func BenchmarkConsumerConcurrentReadWriteSmall(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		ConsumerConcurrentReadWrite(1000)
+	}
+}
+
+func BenchmarkChannelsConcurrentReadWriteSmall(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		ChannelsConcurrentReadWrite(1000)
 	}
 }
 


### PR DESCRIPTION
Add various input sizes to the run functions to benchmark the ring buffer at different input sizes. 