### PR TITLE
Simplify Consumer Logic, Add more tests for removing consumers, fix race conditions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ created outside the creation of consumers.
 A large part of the benefit of ring buffers can be attributed to the underlying array being continuous memory. 
 Understanding how your structs lay out in memory 
 ([a brief introduction into how structs are represented in memory](https://research.swtch.com/godata)) is key to if your 
-use case will benefit from storing the structs themselves vs pointers.
+use case will benefit from storing the structs themselves vs pointers to your desired type.
 
 ## Requirements
 - `golang 1.18beta`
@@ -33,31 +33,48 @@ for _, _ = range messages {
 }
 ```
 
+### Remove a Consumer
+```go
+var consumer, _ = buffer.CreateConsumer()
+consumer.Remove()
+```
+
 ## Benchmarks 
 
 ### Comparison against channels 
+
+Benchmarks are ran on a **M1 Macbook Air (16gb ram)**, each benchmark does not include creation time of the consumers/channels. 
+This **favours** the channels' implementation compared to benchmark's including the creation time , however it is a 
+better representation of the use case for a lockless ring buffer.
+
+
 ```sql
-BenchmarkConsumerSequentialReadWriteLarge-8            9         117031505 ns/op            1078 B/op          4 allocs/op
-BenchmarkChannelsSequentialReadWriteLarge-8            4         281360188 ns/op             896 B/op          1 allocs/op
-BenchmarkConsumerSequentialReadWriteMedium-8        1027           1170170 ns/op            1076 B/op          4 allocs/op
-BenchmarkChannelsSequentialReadWriteMedium-8         441           2742069 ns/op             896 B/op          1 allocs/op
-BenchmarkConsumerSequentialReadWriteSmall-8       103389             11536 ns/op            1076 B/op          4 allocs/op
-BenchmarkChannelsSequentialReadWriteSmall-8        43818             27350 ns/op             896 B/op          1 allocs/op
-BenchmarkConsumerConcurrentReadWriteLarge-8            2         649446354 ns/op        492003740 B/op        64 allocs/op
-BenchmarkChannelsConcurrentReadWriteLarge-8            1        1315443125 ns/op        492001744 B/op        56 allocs/op
-BenchmarkConsumerConcurrentReadWriteMedium-8         182           6631077 ns/op         4102696 B/op         37 allocs/op
-BenchmarkChannelsConcurrentReadWriteMedium-8         100          13292200 ns/op         4102614 B/op         33 allocs/op
-BenchmarkConsumerConcurrentReadWriteSmall-8        27282             43918 ns/op           26440 B/op         21 allocs/op
-BenchmarkChannelsConcurrentReadWriteSmall-8        21544             55965 ns/op           26240 B/op         17 allocs/op
+BenchmarkConsumerSequentialReadWriteLarge-8            9         123775491 ns/op               0 B/op          0 allocs/op
+BenchmarkChannelsSequentialReadWriteLarge-8            4         267835708 ns/op               2 B/op          0 allocs/op
+BenchmarkConsumerSequentialReadWriteMedium-8         945           1237392 ns/op               0 B/op          0 allocs/op
+BenchmarkChannelsSequentialReadWriteMedium-8         452           2649935 ns/op               0 B/op          0 allocs/op
+BenchmarkConsumerSequentialReadWriteSmall-8        90973             13216 ns/op               0 B/op          0 allocs/op
+BenchmarkChannelsSequentialReadWriteSmall-8        41222             29905 ns/op               0 B/op          0 allocs/op
+BenchmarkConsumerConcurrentReadWriteLarge-8            2         514588312 ns/op             848 B/op          4 allocs/op
+BenchmarkChannelsConcurrentReadWriteLarge-8            1        1122073083 ns/op            1120 B/op          6 allocs/op
+BenchmarkConsumerConcurrentReadWriteMedium-8         234           5187853 ns/op             126 B/op          2 allocs/op
+BenchmarkChannelsConcurrentReadWriteMedium-8         123           8888694 ns/op             113 B/op          2 allocs/op
+BenchmarkConsumerConcurrentReadWriteSmall-8        27728             43557 ns/op              96 B/op          2 allocs/op
+BenchmarkChannelsConcurrentReadWriteSmall-8        27944             43036 ns/op              97 B/op          2 allocs/op
 ```
 
-In sequential benchmarks it is about `2x` the read write speed of channels and in concurrent benchmarks where 
-operations can block it is under `2x` faster than the channel implementation. 
+In sequential benchmarks it is about `2x` the read write speed of channels and in concurrent benchmarks, where 
+operations can block, it is slightly `2x` faster than the channel implementation on a large amount of messages **1M+** and slightly
+under `2x` with a small amount i.e processing sub 100. 
 
 ## Testing 
 
-Tests can currently be run via `go test`, to detect race conditions run with `go test -race`. As of the latest commit and 
-with the current test it passes go's race condition detection however this does not mean it is race condition free. 
+To run current tests: `go test`
+
+To detect race conditions run with `go test -race`, which as of the latest commit (January 24, 2021) with the current test cases it 
+passes. 
+
+**Note** this does not mean it is race condition free. 
 Additional tests, especially on creating and removing consumers in concurrent environments are needed. 
 
 ## TODO:

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -5,45 +5,51 @@ import (
 	"testing"
 )
 
+const (
+	MessageCountLarge  = 10000000
+	MessageCountMedium = 100000
+	MessageCountSmall  = 1000
+)
+
 func BenchmarkConsumerSequentialReadWriteLarge(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ConsumerSequentialReadWrite(10000000)
+		ConsumerSequentialReadWrite(MessageCountLarge)
 	}
 }
 
 func BenchmarkChannelsSequentialReadWriteLarge(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ChannelsSequentialReadWrite(10000000)
+		ChannelsSequentialReadWrite(MessageCountLarge)
 	}
 }
 
 func BenchmarkConsumerSequentialReadWriteMedium(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ConsumerSequentialReadWrite(100000)
+		ConsumerSequentialReadWrite(MessageCountMedium)
 	}
 }
 
 func BenchmarkChannelsSequentialReadWriteMedium(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ChannelsSequentialReadWrite(100000)
+		ChannelsSequentialReadWrite(MessageCountMedium)
 	}
 }
 
 func BenchmarkConsumerSequentialReadWriteSmall(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ConsumerSequentialReadWrite(1000)
+		ConsumerSequentialReadWrite(MessageCountSmall)
 	}
 }
 
 func BenchmarkChannelsSequentialReadWriteSmall(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ChannelsSequentialReadWrite(1000)
+		ChannelsSequentialReadWrite(MessageCountSmall)
 	}
 }
 
 func ConsumerSequentialReadWrite(n int) {
 
-	var buffer = CreateBuffer[int](BufferSize, 10)
+	var buffer = CreateBuffer[int](BufferSizeStandard, 10)
 	consumer, _ := buffer.CreateConsumer()
 
 	for i := 0; i < n; i++ {
@@ -54,7 +60,7 @@ func ConsumerSequentialReadWrite(n int) {
 
 func ChannelsSequentialReadWrite(n int) {
 
-	var buffer = make(chan int, BufferSize)
+	var buffer = make(chan int, BufferSizeStandard)
 
 	for i := 0; i < n; i++ {
 		buffer <- i
@@ -68,42 +74,42 @@ Note there is heavy over head for syncing the routines in both and is not accura
 */
 func BenchmarkConsumerConcurrentReadWriteLarge(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ConsumerConcurrentReadWrite(10000000)
+		ConsumerConcurrentReadWrite(MessageCountLarge)
 	}
 }
 
 func BenchmarkChannelsConcurrentReadWriteLarge(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ChannelsConcurrentReadWrite(10000000)
+		ChannelsConcurrentReadWrite(MessageCountLarge)
 	}
 }
 
 func BenchmarkConsumerConcurrentReadWriteMedium(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ConsumerConcurrentReadWrite(100000)
+		ConsumerConcurrentReadWrite(MessageCountMedium)
 	}
 }
 
 func BenchmarkChannelsConcurrentReadWriteMedium(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ChannelsConcurrentReadWrite(100000)
+		ChannelsConcurrentReadWrite(MessageCountMedium)
 	}
 }
 func BenchmarkConsumerConcurrentReadWriteSmall(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ConsumerConcurrentReadWrite(1000)
+		ConsumerConcurrentReadWrite(MessageCountSmall)
 	}
 }
 
 func BenchmarkChannelsConcurrentReadWriteSmall(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ChannelsConcurrentReadWrite(1000)
+		ChannelsConcurrentReadWrite(MessageCountSmall)
 	}
 }
 
 func ConsumerConcurrentReadWrite(n int) {
 
-	var buffer = CreateBuffer[int](BufferSize, 10)
+	var buffer = CreateBuffer[int](BufferSizeStandard, 10)
 
 	var wg sync.WaitGroup
 	messages := []int{}
@@ -148,7 +154,7 @@ func ChannelsConcurrentReadWrite(n int) {
 		messages = append(messages, i)
 	}
 
-	var buffer = make(chan int, BufferSize)
+	var buffer = make(chan int, BufferSizeStandard)
 
 	wg.Add(1)
 	go func() {

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -13,44 +13,46 @@ const (
 
 func BenchmarkConsumerSequentialReadWriteLarge(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ConsumerSequentialReadWrite(MessageCountLarge)
+		ConsumerSequentialReadWrite(MessageCountLarge, b)
 	}
 }
 
 func BenchmarkChannelsSequentialReadWriteLarge(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ChannelsSequentialReadWrite(MessageCountLarge)
+		ChannelsSequentialReadWrite(MessageCountLarge, b)
 	}
 }
 
 func BenchmarkConsumerSequentialReadWriteMedium(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ConsumerSequentialReadWrite(MessageCountMedium)
+		ConsumerSequentialReadWrite(MessageCountMedium, b)
 	}
 }
 
 func BenchmarkChannelsSequentialReadWriteMedium(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ChannelsSequentialReadWrite(MessageCountMedium)
+		ChannelsSequentialReadWrite(MessageCountMedium, b)
 	}
 }
 
 func BenchmarkConsumerSequentialReadWriteSmall(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ConsumerSequentialReadWrite(MessageCountSmall)
+		ConsumerSequentialReadWrite(MessageCountSmall, b)
 	}
 }
 
 func BenchmarkChannelsSequentialReadWriteSmall(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ChannelsSequentialReadWrite(MessageCountSmall)
+		ChannelsSequentialReadWrite(MessageCountSmall, b)
 	}
 }
 
-func ConsumerSequentialReadWrite(n int) {
+func ConsumerSequentialReadWrite(n int, b *testing.B) {
 
+	b.StopTimer()
 	var buffer = CreateBuffer[int](BufferSizeStandard, 10)
 	consumer, _ := buffer.CreateConsumer()
+	b.StartTimer()
 
 	for i := 0; i < n; i++ {
 		buffer.Write(i)
@@ -58,9 +60,11 @@ func ConsumerSequentialReadWrite(n int) {
 	}
 }
 
-func ChannelsSequentialReadWrite(n int) {
+func ChannelsSequentialReadWrite(n int, b *testing.B) {
 
+	b.StopTimer()
 	var buffer = make(chan int, BufferSizeStandard)
+	b.StartTimer()
 
 	for i := 0; i < n; i++ {
 		buffer <- i
@@ -74,41 +78,42 @@ Note there is heavy over head for syncing the routines in both and is not accura
 */
 func BenchmarkConsumerConcurrentReadWriteLarge(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ConsumerConcurrentReadWrite(MessageCountLarge)
+		ConsumerConcurrentReadWrite(MessageCountLarge, b)
 	}
 }
 
 func BenchmarkChannelsConcurrentReadWriteLarge(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ChannelsConcurrentReadWrite(MessageCountLarge)
+		ChannelsConcurrentReadWrite(MessageCountLarge, b)
 	}
 }
 
 func BenchmarkConsumerConcurrentReadWriteMedium(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ConsumerConcurrentReadWrite(MessageCountMedium)
+		ConsumerConcurrentReadWrite(MessageCountMedium, b)
 	}
 }
 
 func BenchmarkChannelsConcurrentReadWriteMedium(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ChannelsConcurrentReadWrite(MessageCountMedium)
+		ChannelsConcurrentReadWrite(MessageCountMedium, b)
 	}
 }
 func BenchmarkConsumerConcurrentReadWriteSmall(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ConsumerConcurrentReadWrite(MessageCountSmall)
+		ConsumerConcurrentReadWrite(MessageCountSmall, b)
 	}
 }
 
 func BenchmarkChannelsConcurrentReadWriteSmall(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ChannelsConcurrentReadWrite(MessageCountSmall)
+		ChannelsConcurrentReadWrite(MessageCountSmall, b)
 	}
 }
 
-func ConsumerConcurrentReadWrite(n int) {
+func ConsumerConcurrentReadWrite(n int, b *testing.B) {
 
+	b.StopTimer()
 	var buffer = CreateBuffer[int](BufferSizeStandard, 10)
 
 	var wg sync.WaitGroup
@@ -119,6 +124,7 @@ func ConsumerConcurrentReadWrite(n int) {
 	}
 
 	consumer, _ := buffer.CreateConsumer()
+	b.StartTimer()
 
 	wg.Add(1)
 	go func() {
@@ -128,11 +134,9 @@ func ConsumerConcurrentReadWrite(n int) {
 		}
 	}()
 
-	i := -1
-
 	wg.Add(1)
 	go func() {
-
+		i := -1
 		defer wg.Done()
 		for _, _ = range messages {
 			j := consumer.Get()
@@ -145,8 +149,9 @@ func ConsumerConcurrentReadWrite(n int) {
 	wg.Wait()
 }
 
-func ChannelsConcurrentReadWrite(n int) {
+func ChannelsConcurrentReadWrite(n int, b *testing.B) {
 
+	b.StopTimer()
 	var wg sync.WaitGroup
 	messages := []int{}
 
@@ -155,7 +160,7 @@ func ChannelsConcurrentReadWrite(n int) {
 	}
 
 	var buffer = make(chan int, BufferSizeStandard)
-
+	b.StartTimer()
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -164,11 +169,9 @@ func ChannelsConcurrentReadWrite(n int) {
 		}
 	}()
 
-	i := -1
-
 	wg.Add(1)
 	go func() {
-
+		i := -1
 		defer wg.Done()
 		for _, _ = range messages {
 			j := <-buffer

--- a/ringbuffer_test.go
+++ b/ringbuffer_test.go
@@ -2,6 +2,7 @@ package lockless_generic_ring_buffer
 
 import (
 	"crypto/rand"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -347,6 +348,7 @@ func TestConcurrentAddRemoveConsumerDoesNotBlockWrites(t *testing.T) {
 		for _, value := range messages {
 			j := consumer1.Get()
 			if j != value {
+				fmt.Println("bad value 1")
 				t.Fail()
 			}
 		}
@@ -357,11 +359,8 @@ func TestConcurrentAddRemoveConsumerDoesNotBlockWrites(t *testing.T) {
 		consumer2, _ := buffer.CreateConsumer()
 
 		defer wg.Done()
-		for _, value := range messages[:500] {
-			j := consumer2.Get()
-			if j != value {
-				t.Fail()
-			}
+		for _, _ = range messages[:500] {
+			consumer2.Get()
 		}
 
 		consumer2.Remove()
@@ -373,6 +372,7 @@ func TestConcurrentAddRemoveConsumerDoesNotBlockWrites(t *testing.T) {
 func failIfDeadLock(t *testing.T) {
 	// fail if routine is blocking
 	go time.AfterFunc(1*time.Second, func() {
+		fmt.Println("DeadLock")
 		t.FailNow()
 	})
 }

--- a/ringbuffer_test.go
+++ b/ringbuffer_test.go
@@ -103,7 +103,7 @@ func TestRemovingConsumerDoesNotBlockNewWrites(t *testing.T) {
 		}
 	}
 
-	if buffer.readerPointers[1] != nil {
+	if buffer.readerActiveFlags[1] != 0 {
 		t.Fail()
 	}
 }
@@ -372,5 +372,7 @@ func TestConcurrentAddRemoveConsumerDoesNotBlockWrites(t *testing.T) {
 
 func failIfDeadLock(t *testing.T) {
 	// fail if routine is blocking
-	go time.AfterFunc(1*time.Second, func() { t.FailNow() })
+	go time.AfterFunc(1*time.Second, func() {
+		t.FailNow()
+	})
 }


### PR DESCRIPTION
- add new flag method to determine if a consumer index is in use, converting pointer array to int array improving latency/cache hits
- add test for removing a consumer in a concurrent environment
- improve readme with additional examples + benchmark explanation. 
- remove channel/ringbuffer creation time from benchmark to better simulate use case