### PR TITLE
fixed consumer logic error for when in adding new consumer state

### DIFF
--- a/ringbuffer.go
+++ b/ringbuffer.go
@@ -55,7 +55,7 @@ an unclaimed/not used consumer.
 func (ringbuffer *RingBuffer[T]) CreateConsumer() (Consumer[T], error) {
 
 	for newConsumerId, _ := range ringbuffer.readerActiveFlags {
-		if atomic.CompareAndSwapUint32(&ringbuffer.readerActiveFlags[newConsumerId], 0, 1) {
+		if atomic.CompareAndSwapUint32(&ringbuffer.readerActiveFlags[newConsumerId], 0, 2) {
 
 			if uint32(newConsumerId) >= ringbuffer.maximumConsumerId {
 				atomic.AddUint32(&ringbuffer.maximumConsumerId, 1)


### PR DESCRIPTION
Set state to creation instead on ready for consumers on creation while creation operations are on going to avoid race condition. 