### PR TITLE
Remove Consumer Lock, Simplify Indexing of Read/Write And Reduce Write Branching Operation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 This is an implementation of a single producer, multi reader lockless ring buffer utilizing the new generics available in 
 `go 1.18`. Instead of passing typeless `interface{}` which we have to assert or deserialized `[]byte`'s we are able to 
-pass serialized structs between go routines in a type safe manner.
+pass serialized structs between go routines in a type safe manner. 
+
+**Note: the current implementation writer is NOT thread safe** 
+
 
 This package goes to great lengths not to allocate in the critical path and thus makes `0` allocations once the buffer is 
 created outside the creation of consumers. 
@@ -13,7 +16,7 @@ Understanding how your structs lay out in memory
 use case will benefit from storing the structs themselves vs pointers to your desired type.
 
 ## Requirements
-- `golang 1.18beta`
+- `golang 1.18.x or above`
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is an implementation of a single producer, multi reader lockless ring buffe
 `go 1.18`. Instead of passing typeless `interface{}` which we have to assert or deserialized `[]byte`'s we are able to 
 pass serialized structs between go routines in a type safe manner. 
 
-**Note: the current implementation writer is NOT thread safe** 
+**Note: the current implementation writers nor individual consumers is NOT thread safe, i.e. one consumer per go routine** 
 
 
 This package goes to great lengths not to allocate in the critical path and thus makes `0` allocations once the buffer is 
@@ -52,19 +52,19 @@ better representation of the use case for a lockless ring buffer.
 
 
 ```sql
-pkg: lockless_generic_ring_buffer
-BenchmarkConsumerSequentialReadWriteLarge-8           24          49058092 ns/op               0 B/op          0 allocs/op
-BenchmarkChannelsSequentialReadWriteLarge-8            8         133992614 ns/op               1 B/op          0 allocs/op
-BenchmarkConsumerSequentialReadWriteMedium-8        1200           1003891 ns/op               0 B/op          0 allocs/op
-BenchmarkChannelsSequentialReadWriteMedium-8         447           2680120 ns/op               0 B/op          0 allocs/op
-BenchmarkConsumerSequentialReadWriteSmall-8       109717             10922 ns/op               0 B/op          0 allocs/op
-BenchmarkChannelsSequentialReadWriteSmall-8        41360             28959 ns/op               0 B/op          0 allocs/op
-BenchmarkConsumerConcurrentReadWriteLarge-8            4         268338386 ns/op             512 B/op          3 allocs/op
-BenchmarkChannelsConcurrentReadWriteLarge-8            2         779468271 ns/op             448 B/op          4 allocs/op
-BenchmarkConsumerConcurrentReadWriteMedium-8         222           5181917 ns/op             132 B/op          2 allocs/op
-BenchmarkChannelsConcurrentReadWriteMedium-8          82          16977129 ns/op             134 B/op          2 allocs/op
-BenchmarkConsumerConcurrentReadWriteSmall-8        31675             37890 ns/op              96 B/op          2 allocs/op
-BenchmarkChannelsConcurrentReadWriteSmall-8        24438             49717 ns/op              97 B/op          2 allocs/op
+BenchmarkConsumerSequentialReadWriteLarge-8           20          55602675 ns/op               0 B/op          0 allocs/op
+BenchmarkChannelsSequentialReadWriteLarge-8            8         133155344 ns/op               0 B/op          0 allocs/op
+BenchmarkConsumerSequentialReadWriteMedium-8        1063           1123298 ns/op               0 B/op          0 allocs/op
+BenchmarkChannelsSequentialReadWriteMedium-8         451           2650842 ns/op               0 B/op          0 allocs/op
+BenchmarkConsumerSequentialReadWriteSmall-8        99393             12099 ns/op               0 B/op          0 allocs/op
+BenchmarkChannelsSequentialReadWriteSmall-8        41755             28758 ns/op               0 B/op          0 allocs/op
+BenchmarkConsumerConcurrentReadWriteLarge-8            5         223985800 ns/op             345 B/op          2 allocs/op
+BenchmarkChannelsConcurrentReadWriteLarge-8            2         858931292 ns/op             144 B/op          2 allocs/op
+BenchmarkConsumerConcurrentReadWriteMedium-8         278           4554057 ns/op             217 B/op          2 allocs/op
+BenchmarkChannelsConcurrentReadWriteMedium-8          90          17578294 ns/op             169 B/op          2 allocs/op
+BenchmarkConsumerConcurrentReadWriteSmall-8        36378             33837 ns/op              96 B/op          2 allocs/op
+BenchmarkChannelsConcurrentReadWriteSmall-8        25004             47466 ns/op              97 B/op          2 allocs/op
+
 ```
 
 In sequential benchmarks it is about `2x` the read write speed of channels and in concurrent benchmarks, where 

--- a/ringbuffer_test.go
+++ b/ringbuffer_test.go
@@ -17,7 +17,7 @@ func TestGetsAreSequentiallyOrdered(t *testing.T) {
 
 	//ring := make([]int, 10, 10)
 
-	var buffer, _ = CreateBuffer[int](BufferSizeStandard, 10)
+	var buffer, _ = CreateBuffer[int](BufferSizeSmall, 10)
 
 	messages := []int{1, 2, 3, 4, 5, 6, 7, 8, 9}
 	consumer, _ := buffer.CreateConsumer()
@@ -130,18 +130,14 @@ func TestConcurrentGetsAreSequentiallyOrdered(t *testing.T) {
 		}
 	}()
 
-	i := -1
-
 	wg.Add(1)
 	go func() {
-
 		defer wg.Done()
-		for _, _ = range messages {
+		for _, value := range messages {
 			j := consumer.Get()
-			if j != i+1 {
+			if j != value {
 				t.Fail()
 			}
-			i = j
 		}
 	}()
 	wg.Wait()
@@ -169,18 +165,14 @@ func TestConcurrentGetsAreSequentiallyOrderedMinibuffer(t *testing.T) {
 		}
 	}()
 
-	i := -1
-
 	wg.Add(1)
 	go func() {
-
 		defer wg.Done()
-		for _, _ = range messages {
+		for _, value := range messages {
 			j := consumer.Get()
-			if j != i+1 {
+			if j != value {
 				t.Fail()
 			}
-			i = j
 		}
 	}()
 	wg.Wait()
@@ -213,40 +205,34 @@ func TestConcurrentStringsGetsAreSequentiallyOrderedWithMultiConsumer(t *testing
 
 	wg.Add(1)
 	go func() {
-		//i := -1
 		defer wg.Done()
 		for _, value := range messages {
 			j := consumer1.Get()
 			if j != value {
 				t.Fail()
 			}
-			//i = j
 		}
 	}()
 
 	wg.Add(1)
 	go func() {
-		//i := -1
 		defer wg.Done()
 		for _, value := range messages {
 			j := consumer2.Get()
 			if j != value {
 				t.Fail()
 			}
-			//i = j
 		}
 	}()
 
 	wg.Add(1)
 	go func() {
-		//i := -1
 		defer wg.Done()
 		for _, value := range messages {
 			j := consumer3.Get()
 			if j != value {
 				t.Fail()
 			}
-			//i = j
 		}
 	}()
 	wg.Wait()
@@ -278,40 +264,34 @@ func TestConcurrentGetsAreSequentiallyOrderedWithMultiConsumer(t *testing.T) {
 
 	wg.Add(1)
 	go func() {
-		//i := -1
 		defer wg.Done()
 		for _, value := range messages {
 			j := consumer1.Get()
 			if j != value {
 				t.Fail()
 			}
-			//i = j
 		}
 	}()
 
 	wg.Add(1)
 	go func() {
-		//i := -1
 		defer wg.Done()
 		for _, value := range messages {
 			j := consumer2.Get()
 			if j != value {
 				t.Fail()
 			}
-			//i = j
 		}
 	}()
 
 	wg.Add(1)
 	go func() {
-		//i := -1
 		defer wg.Done()
 		for _, value := range messages {
 			j := consumer3.Get()
 			if j != value {
 				t.Fail()
 			}
-			//i = j
 		}
 	}()
 	wg.Wait()
@@ -355,7 +335,6 @@ func TestConcurrentAddRemoveConsumerDoesNotBlockWrites(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		consumer2, _ := buffer.CreateConsumer()
-
 		defer wg.Done()
 		for _, _ = range messages[:500] {
 			consumer2.Get()

--- a/ringbuffer_test.go
+++ b/ringbuffer_test.go
@@ -311,7 +311,7 @@ func TestConcurrentAddRemoveConsumerDoesNotBlockWrites(t *testing.T) {
 
 	consumer1, _ := buffer.CreateConsumer()
 
-	failIfDeadLock(t)
+	//failIfDeadLock(t)
 
 	wg.Add(1)
 	go func() {

--- a/ringbuffer_test.go
+++ b/ringbuffer_test.go
@@ -310,8 +310,7 @@ func TestConcurrentAddRemoveConsumerDoesNotBlockWrites(t *testing.T) {
 	}
 
 	consumer1, _ := buffer.CreateConsumer()
-
-	//failIfDeadLock(t)
+	failIfDeadLock(t)
 
 	wg.Add(1)
 	go func() {


### PR DESCRIPTION
=> Change reader, writer index logic to now mean that the value of the index is the last value read/written to.
=> Change loop operations on readers to now yield on first indication write is not currently possible.  Replace loop and if statements with goto to retry write on failure reducing branching on successful and yielding write operations. This improves speed significantly in concurrent environments. 
=> refactor buffer itself to use consistent naming for reader value
=> make tests use same implementation to ensure read/write order is consistent 
=> Update readme with new benchmarks